### PR TITLE
#12: avoid JS, #13: use parent, #14: increase UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ jsclient/
 eclipse-target/
 **/src/generated/
 **/tmp/
+#Special case only in docgen cause README is copied to modules
+**/README.asciidoc
 
 # Package Files #
 *.jar

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,10 @@ eclipse-target/
 **/src/generated/
 **/tmp/
 #Special case only in docgen cause README is copied to modules
-**/README.asciidoc
+all/documentation
+pdf/documentation
+init/documentation
+html/documentation
 
 # Package Files #
 *.jar

--- a/.gitignore
+++ b/.gitignore
@@ -1,22 +1,21 @@
-/target
-/.settings
 *.class
 *.classpath
 *.project
 *.iml
+*.jar
+*.war
+*.ear
 .*
+!.gitignore
+!.travis.yml
+!.mvn
 target/
-jsclient/
 eclipse-target/
 **/src/generated/
 **/tmp/
-#Special case only in docgen cause README is copied to modules
+
+#Special case only in docgen cause documentation is copied to modules
 all/documentation
 pdf/documentation
 init/documentation
 html/documentation
-
-# Package Files #
-*.jar
-*.war
-*.ear

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Drevision=5.0.0 -Dchangelist=-SNAPSHOT

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -11,13 +11,13 @@ image:https://img.shields.io/github/license/devonfw/devon-docgen.svg?label=Licen
 image:https://img.shields.io/maven-central/v/com.devonfw.tools/devon-docgen.svg?label=Maven%20Central["Maven Central",link=https://search.maven.org/search?q=g:com.devonfw.tools+a:devon-docgen]
 image:https://travis-ci.org/devonfw/devon-docgen.svg?branch=master["Build Status",link="https://travis-ci.org/devonfw/devon-docgen"]
 
-DocGen is a tool that can generate a complete and self-contained documentation as PDF and HTML from Asciidoc wiki pages.
+DocGen is a tool that can generate a complete and self-contained documentation as PDF, ePub or HTML from Asciidoc pages.
 
 == Features
 With DocGen you can
 
-* maintain documentation on github wiki as individual pages using http://www.methods.co.nz/asciidoc[asciidoc] based on our xref:guidelines[guidelines].
-* generate a single and self-contained document as `PDF` or `HTML` from it
+* maintain documentation on github in a folder together with you code or in github wiki as individual pages using http://www.methods.co.nz/asciidoc[asciidoc] based on our xref:guidelines[guidelines].
+* generate a single and self-contained document as `PDF`, `ePub` or `HTML` from it
 * convert links between wiki pages into document internal links
 * have a single table of contents per complete document as well as per wiki page
 
@@ -34,8 +34,8 @@ With DocGen you can
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.devonfw.tools</groupId>
-    <artifactId>devon-docgen</artifactId>
-    <version>4.0.0</version>
+    <artifactId>devonfw-docgen-«format»</artifactId>
+    <version>5.0.0</version>
   </parent>
   <groupId>my.group.id</groupId>
   <artifactId>my-artifact-id</artifactId>
@@ -44,15 +44,13 @@ With DocGen you can
   <name>My Cool Wiki</name>
 
   <properties>
-    <docgen.wiki.page>my-main-page</docgen.wiki.page>
-  </properties>
-
-  <!-- run "mvn package -Doutput.format=pdf" and get the PDF result in target/generated-docs/*.pdf -->
-  
-  <!-- run "mvn package -Doutput.format=html" and get the HTML5 result in target/generated-docs/* -->
-  
+    <docgen.wiki.page>«main-page»</docgen.wiki.page>
+  </properties>  
 </project>
 ```
+For `«format»` please fill in `pdf`, `html`, `epub`, or `all` to decide which format(s) you want to generate.
+For «main-page» fill in the filename of your main AsciiDoc file (without extension) to use as entry point for the generation.
+This file should contain the main title and configuration together with all the `include` directives to the individual AsciiDoc pages to include into your document.
 3. Add, commit and push it to github:
 +
 [source,cmd]
@@ -62,10 +60,10 @@ git commit -m "added pom.xml for docgen"
 git push
 --------
 4. Optional custom theme:
-You can develop your own style by using the asciidoctor facilities. Therefore create your own theme in the path `theme/custom-theme.yml` and also push it to the wiki git repo.
+You can develop your own style by using the asciidoctor facilities. Therefore create your own theme in the path `theme/custom-theme.yml` and also push it together with your documentation.
 
 == Usage
-To start the generation manually you need to clone the wiki with the documentation to generate as described above. Then open a command shell in the cloned project and call:
+To start the generation manually you need to clone the documentation to generate as described above. Then open a command shell in the cloned project and call:
 [source,cmd]
 --------
 mvn clean package
@@ -76,22 +74,17 @@ Then you will find the result in `target/generated-docs/`.
 If you want to deploy your documentation to maven central run:
 [source,cmd]
 --------
-mvn deploy -Dgpg.keyname=<yourkeyname> -Poss
+mvn deploy -Pdeploy
 --------
 
-It is a common practice to store all the images used in a folder called "images", so docgen search in "images" as default. If you want to specify other directory or multiple, it can be done as follows:
-
-[source,cmd]
---------
-mvn clean package -Doutput.format=pdf -Ddocgen.images.dir=images1,images2,...,imagesn
---------
+== Configuration
+It is a common practice to store all the images used in a folder called "images", so docgen search in "images" as default. If you want to specify other directory or multiple, you can override the variable `docgen.images.dir` in your POM. There are many other properties you may want to override to tweak and customize your generation. For details see our `pom.xml` files and read the https://asciidoctor.org/docs/asciidoctor-maven-plugin/#configuration[asciidoctor-maven-plugin documentation].
 
 == Guidelines
 In order to make DocGen work properly please follow these guidelines:
 
-* Maintain the documentation as collection of wiki pages. 
-* For the wiki usage link (important) pages in the sidebar for navigation.
-* Use http://www.methods.co.nz/asciidoc/[AsciiDoc] for all wiki pages. This is not the default on github. Always switch `Edit mode` to `AsciiDoc` when creating new wiki pages.
+* Maintain the documentation as collection of http://www.methods.co.nz/asciidoc/[AsciiDoc] pages.
+* If you are using github wikis this is not the default: Always switch `Edit mode` to `AsciiDoc` when creating new wiki pages.
 * For help on the syntax consult the http://asciidoctor.org/docs/asciidoc-writers-guide/[writers guide] and the https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[quick reference].
 * Start every page with the following AsciiDoc header:
 +
@@ -103,12 +96,12 @@ toc::[]
 :idseparator: -
 --------
 +
-* In order to make internal links work both in wiki as well as in generated documentation (PDF, ePub, HTML) you need to stick to this rules:
+* In order to make internal links work both in asciidoc pages as well as in generated documentation (PDF, ePub, HTML) you need to stick to this rules:
 ** Do not use special characters (dot, ampersand, etc.) in section titles (use plain text e.g. "My Section")
-** If you link to a section, you simply use the section title in lower case with hyphens instead of spaces (e.g. "my-section"). Within the same wiki page you use `xref` (e.g. `xref :my-section[link title]`) and between wiki pages you use `link` (e.g. `link :guide-my-topic#my-section[link title]`).
-** In case you want to reference the top-level section of a wiki page you need to use +link+ without a section reference (e.g. `link :guide-my-topic[link title]`) and NOT `xref` even if you place the link within the same wiki page.
-** From wiki pages included in the generated documentation only use `link:` to other wiki pages that will also be part of the generated documentation. Otherwise you would produce dead links.
-* For editing larger files and offline work we recommend to clone the wiki with git and use an xref:asciidoc-tools[AsciiDoc editor tool].
+** If you link to a section, you simply use the section title in lower case with hyphens instead of spaces (e.g. "my-section"). Within the same asciidoc page you use `xref` (e.g. `xref :my-section[link title]`) and between asciidoc pages you use `link` (e.g. `link :«pagename».asciidoc#«section-name»[«link title»]`).
+** In case you want to reference the top-level section of a wiki page you need to use +link+ without a section reference (e.g. `link :«pagename».asciidoc[«link title»]`) and NOT `xref` even if you place the link within the same asciidoc page.
+** From asciidoc pages included in the generated documentation only use `link:` to other asciidoc pages that will also be part of the generated documentation. Otherwise you would produce dead links.
+* For editing larger files and offline work we recommend to clone the asciidoc documentation with git and use an xref:asciidoc-tools[AsciiDoc editor tool].
 * You need to ensure that the files use UTF-8 as encoding.
 * To include images you need to follow this rules:
 ** The best choice for high quality rendering is `SVG`. As the wiki does not create mimetypes you have to 
@@ -118,19 +111,19 @@ put the image on the https://github.com/devonfw/devonfw.github.io/[github pages]
 [source,asciidoc]
 --------
 .Image Title
-image::http://devonfw.github.io/devon4j/images/MyImage.svg["alt-text", width="450", link="http://devonfw.github.io/devon4j/images/MyImage.svg"]
+image::http://devonfw.github.io/devon4j/images/«MyImage».«format»["alt-text", width="450", link="http://devonfw.github.io/devon4j/images/«MyImage».«format»"]
 --------
-* For devonfw the wiki pages belong to categories that are also reflected by a naming convention:
+* For devonfw the asciidoc pages belong to categories that are also reflected by a naming convention:
 ** `coding-*` is used for pages about general aspects to development and writing code.
 ** `guide-*` is used for pages that act as a guide to a specific topic. It describes what to do and how to do it for that topic from the perspective of a developer.
 ** `alternative-*` is used for pages that are not part of the suggested standard but are commonly used or popular alternatives to a proposed standard solution. Such page explains how to use such an alternative solution.
 ** `architecture` is reserved for the architecture documentation.
 ** `introduction-*` is used for pages that are part of the introduction into the documentation (motivation and general goals).
-** `devon-*` is used for pages that are about the devonfw itself and will not be part of the official documentation.
+** `devonfw-*` is used for pages that are about the devonfw itself and will not be part of the official documentation.
 ** `tutorial-*` is used for pages that are part of the tutorials.
 
 == Migration
-If you migrate from devon-docgen 3.x to 4.x generating PDFs, you now have to add `-Doutput.format=pdf` to your maven build command. Similarly, for html generation it would be `-Doutput.format=html`.
+If you migrate from devon-docgen, you have to choose your target output format to generate via the `artifactId` of the `docgen` parent in your `pom.xml` (see `«format»` above). So instead of the `artifactId` which was `devon-docgen` you now have to use `devonfw-docgen-pdf` (or `devonfw-docgen-html` in case you generate HTML output).
 
 == Tooling
 Our DocGen tool is technically based on the following tools:
@@ -138,13 +131,10 @@ Our DocGen tool is technically based on the following tools:
 * http://maven.apache.org[maven]
 * http://asciidoctor.org[asciidoctor]
 ** via http://asciidoctor.org/docs/asciidoctor-maven-plugin[asciidoctor-maven-plugin]
-* http://www.docbook.org[docbook]
-** via http://docbkx-tools.sourceforge.net/docbkx-maven-plugin/plugin-info.html[docbkx-maven-plugin]
-** using http://docbook.sourceforge.net/release/xsl/current[docbook XSL distribution]
 * http://ant.apache.org[ant]
 ** via http://maven.apache.org/plugins/maven-antrun-plugin[maven-antrun-plugin]
 
-This setup was inspired by https://github.com/spring-projects/spring-boot/tree/master/spring-boot-docs/[spring-boot-docs] and improved for link processing, etc.
+This setup was inspired by https://github.com/spring-projects/spring-boot/tree/master/spring-boot-docs/[spring-boot-docs] and improved for link processing, ease of use, etc.
 Feel free to get inspired here or copy the entire solution if you like it.
 Thanks to all authors of the actual tools and to spring-boot for making this great DocGen happen.
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1,150 +1,17 @@
-:toc: right
+= devonfw-docgen
 
-= devonfw Documentation Generator
-The devonfw community
-${project.version}, ${buildtime}: Subtitle {doctitle}
-
-:toc:
-toc::[]
+`devonfw-docgen` is a tool that can generate a complete and self-contained documentation as PDF, ePub or HTML from Asciidoc pages.
 
 image:https://img.shields.io/github/license/devonfw/devon-docgen.svg?label=License["Apache License, Version 2.0",link=https://github.com/devonfw/devon-docgen/blob/develop/LICENSE]
 image:https://img.shields.io/maven-central/v/com.devonfw.tools/devon-docgen.svg?label=Maven%20Central["Maven Central",link=https://search.maven.org/search?q=g:com.devonfw.tools+a:devon-docgen]
 image:https://travis-ci.org/devonfw/devon-docgen.svg?branch=master["Build Status",link="https://travis-ci.org/devonfw/devon-docgen"]
 
-DocGen is a tool that can generate a complete and self-contained documentation as PDF, ePub or HTML from Asciidoc pages.
+== Documentation
 
-== Features
-With DocGen you can
+* link:documentation/features.asciidoc[Features]
+* link:documentation/usage.asciidoc[Usage]
+* link:documentation/guidelines.asciidoc[Guidelines]
+* link:documentation/migration.asciidoc[Migration]
+* link:documentation/tools.asciidoc[AsciiDoc Tools]
+* link:documentation/credits.asciidoc[Credits]
 
-* maintain documentation on github in a folder together with you code or in github wiki as individual pages using http://www.methods.co.nz/asciidoc[asciidoc] based on our xref:guidelines[guidelines].
-* generate a single and self-contained document as `PDF`, `ePub` or `HTML` from it
-* convert links between wiki pages into document internal links
-* have a single table of contents per complete document as well as per wiki page
-
-== Setup
-
-1. Clone your github wiki using git to your local machine
-2. Create a pom.xml in the cloned wiki directory with the following content:
-+
-```xml
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>com.devonfw.tools</groupId>
-    <artifactId>devonfw-docgen-«format»</artifactId>
-    <version>5.0.0</version>
-  </parent>
-  <groupId>my.group.id</groupId>
-  <artifactId>my-artifact-id</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
-  <packaging>jar</packaging>
-  <name>My Cool Wiki</name>
-
-  <properties>
-    <docgen.wiki.page>«main-page»</docgen.wiki.page>
-  </properties>  
-</project>
-```
-For `«format»` please fill in `pdf`, `html`, `epub`, or `all` to decide which format(s) you want to generate.
-For «main-page» fill in the filename of your main AsciiDoc file (without extension) to use as entry point for the generation.
-This file should contain the main title and configuration together with all the `include` directives to the individual AsciiDoc pages to include into your document.
-3. Add, commit and push it to github:
-+
-[source,cmd]
---------
-git add pom.xml
-git commit -m "added pom.xml for docgen"
-git push
---------
-4. Optional custom theme:
-You can develop your own style by using the asciidoctor facilities. Therefore create your own theme in the path `theme/custom-theme.yml` and also push it together with your documentation.
-
-== Usage
-To start the generation manually you need to clone the documentation to generate as described above. Then open a command shell in the cloned project and call:
-[source,cmd]
---------
-mvn clean package
---------
-
-Then you will find the result in `target/generated-docs/`.
-
-If you want to deploy your documentation to maven central run:
-[source,cmd]
---------
-mvn deploy -Pdeploy
---------
-
-== Configuration
-It is a common practice to store all the images used in a folder called "images", so docgen search in "images" as default. If you want to specify other directory or multiple, you can override the variable `docgen.images.dir` in your POM. There are many other properties you may want to override to tweak and customize your generation. For details see our `pom.xml` files and read the https://asciidoctor.org/docs/asciidoctor-maven-plugin/#configuration[asciidoctor-maven-plugin documentation].
-
-== Guidelines
-In order to make DocGen work properly please follow these guidelines:
-
-* Maintain the documentation as collection of http://www.methods.co.nz/asciidoc/[AsciiDoc] pages.
-* If you are using github wikis this is not the default: Always switch `Edit mode` to `AsciiDoc` when creating new wiki pages.
-* For help on the syntax consult the http://asciidoctor.org/docs/asciidoc-writers-guide/[writers guide] and the https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[quick reference].
-* Start every page with the following AsciiDoc header:
-+
-[source,asciidoc]
---------
-:toc: macro
-toc::[]
-:idprefix:
-:idseparator: -
---------
-+
-* In order to make internal links work both in asciidoc pages as well as in generated documentation (PDF, ePub, HTML) you need to stick to this rules:
-** Do not use special characters (dot, ampersand, etc.) in section titles (use plain text e.g. "My Section")
-** If you link to a section, you simply use the section title in lower case with hyphens instead of spaces (e.g. "my-section"). Within the same asciidoc page you use `xref` (e.g. `xref :my-section[link title]`) and between asciidoc pages you use `link` (e.g. `link :«pagename».asciidoc#«section-name»[«link title»]`).
-** In case you want to reference the top-level section of a wiki page you need to use +link+ without a section reference (e.g. `link :«pagename».asciidoc[«link title»]`) and NOT `xref` even if you place the link within the same asciidoc page.
-** From asciidoc pages included in the generated documentation only use `link:` to other asciidoc pages that will also be part of the generated documentation. Otherwise you would produce dead links.
-* For editing larger files and offline work we recommend to clone the asciidoc documentation with git and use an xref:asciidoc-tools[AsciiDoc editor tool].
-* You need to ensure that the files use UTF-8 as encoding.
-* To include images you need to follow this rules:
-** The best choice for high quality rendering is `SVG`. As the wiki does not create mimetypes you have to 
-put the image on the https://github.com/devonfw/devonfw.github.io/[github pages].
-** You have to set the size so it gets properly rendered in the PDF. The width value to make it fit properly on the PDF page is `450`:
-+
-[source,asciidoc]
---------
-.Image Title
-image::http://devonfw.github.io/devon4j/images/«MyImage».«format»["alt-text", width="450", link="http://devonfw.github.io/devon4j/images/«MyImage».«format»"]
---------
-* For devonfw the asciidoc pages belong to categories that are also reflected by a naming convention:
-** `coding-*` is used for pages about general aspects to development and writing code.
-** `guide-*` is used for pages that act as a guide to a specific topic. It describes what to do and how to do it for that topic from the perspective of a developer.
-** `alternative-*` is used for pages that are not part of the suggested standard but are commonly used or popular alternatives to a proposed standard solution. Such page explains how to use such an alternative solution.
-** `architecture` is reserved for the architecture documentation.
-** `introduction-*` is used for pages that are part of the introduction into the documentation (motivation and general goals).
-** `devonfw-*` is used for pages that are about the devonfw itself and will not be part of the official documentation.
-** `tutorial-*` is used for pages that are part of the tutorials.
-
-== Migration
-If you migrate from devon-docgen, you have to choose your target output format to generate via the `artifactId` of the `docgen` parent in your `pom.xml` (see `«format»` above). So instead of the `artifactId` which was `devon-docgen` you now have to use `devonfw-docgen-pdf` (or `devonfw-docgen-html` in case you generate HTML output).
-
-== Tooling
-Our DocGen tool is technically based on the following tools:
-
-* http://maven.apache.org[maven]
-* http://asciidoctor.org[asciidoctor]
-** via http://asciidoctor.org/docs/asciidoctor-maven-plugin[asciidoctor-maven-plugin]
-* http://ant.apache.org[ant]
-** via http://maven.apache.org/plugins/maven-antrun-plugin[maven-antrun-plugin]
-
-This setup was inspired by https://github.com/spring-projects/spring-boot/tree/master/spring-boot-docs/[spring-boot-docs] and improved for link processing, ease of use, etc.
-Feel free to get inspired here or copy the entire solution if you like it.
-Thanks to all authors of the actual tools and to spring-boot for making this great DocGen happen.
-
-== AsciiDoc Tools
-You can checkout a github wiki as a git repository and edit it with an editor of your choice. For this we recommend the following tools:
-
-* http://www.asciidocfx.com/[AsciiDocFx]
-* https://plugins.jetbrains.com/plugin/7391-asciidoc[AsciiDoc for IntelliJ]
-* https://marketplace.visualstudio.com/items?itemName=joaompinto.asciidoctor-vscode[AsciiDoc for VS Code]
-* https://addons.mozilla.org/fr/firefox/addon/asciidoctorjs-live-preview/[Asciidoc for Firefox]
-* https://chrome.google.com/webstore/detail/asciidoctorjs-live-previe/iaalpfgpbocpdfblpnhhgllgbdbchmia[Asciidoc for Chrome]
-* https://atom.io/packages/asciidoc-preview[Asciidoc preview for Atom] and https://atom.io/packages/language-asciidoc[Asciidoc language for Atom]
-* https://github.com/asciidoctor/brackets-asciidoc-preview[Asciidoc for Brackets]

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -47,7 +47,7 @@
               <skip>${asciidoctor.skip}</skip>
               <artifacts>
                 <artifact>
-                  <file>${docgen.generated.docs}/${docgen.wiki.page}.pdf</file>
+                  <file>${docgen.generated.docs}/${docgen.asciidoc.page}.pdf</file>
                   <type>pdf</type>
                 </artifact>
               </artifacts>

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.devonfw.tools</groupId>
+    <artifactId>devonfw-docgen</artifactId>
+    <version>${revision}${changelist}</version>
+  </parent>
+  <artifactId>devonfw-docgen-all</artifactId>
+  <packaging>pom</packaging>
+  <name>${project.artifactId}</name>
+  <description>Generates documentation as PDF and HTML from AsciiDoc pages.</description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.asciidoctor</groupId>
+        <artifactId>asciidoctor-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>generate-html</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>process-asciidoc</goal>
+            </goals>
+            <configuration>
+              <backend>html5</backend>
+              <sourceHighlighter>highlightjs</sourceHighlighter>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-pdf</id>
+            <goals>
+              <goal>attach-artifact</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <skip>${asciidoctor.skip}</skip>
+              <artifacts>
+                <artifact>
+                  <file>${docgen.generated.docs}/${docgen.wiki.page}.pdf</file>
+                  <type>pdf</type>
+                </artifact>
+              </artifacts>
+              <archive>
+                <addMavenDescriptor>true</addMavenDescriptor>
+              </archive>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.devonfw.tools</groupId>
     <artifactId>devonfw-docgen</artifactId>
-    <version>${revision}${changelist}</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>devonfw-docgen-all</artifactId>
   <packaging>pom</packaging>

--- a/documentation/credits.asciidoc
+++ b/documentation/credits.asciidoc
@@ -1,0 +1,13 @@
+= Credits
+
+`devonfw-docgen` tool is technically based on the following tools:
+
+* http://maven.apache.org[maven]
+* http://asciidoctor.org[asciidoctor]
+** via http://asciidoctor.org/docs/asciidoctor-maven-plugin[asciidoctor-maven-plugin]
+* http://ant.apache.org[ant]
+** via http://maven.apache.org/plugins/maven-antrun-plugin[maven-antrun-plugin]
+
+This setup was inspired by https://github.com/spring-projects/spring-boot/tree/master/spring-boot-docs/[spring-boot-docs] and improved for link processing, ease of use, etc.
+Feel free to get inspired here or copy the entire solution if you like it.
+Thanks to all authors of the actual tools and to spring-boot for making this great `devonfw-docgen` possible.

--- a/documentation/features.asciidoc
+++ b/documentation/features.asciidoc
@@ -1,0 +1,7 @@
+= Features
+With devonfw-docgen you can
+
+* maintain documentation on github in a folder together with you code or in github wiki as individual pages using http://www.methods.co.nz/asciidoc[asciidoc] based on our link:guidelines.asciidoc[guidelines].
+* generate a single and self-contained document as `PDF`, `ePub` or `HTML` from it
+* convert links between wiki pages into document internal links
+* have a single table of contents per complete document as well as per wiki page

--- a/documentation/guidelines.asciidoc
+++ b/documentation/guidelines.asciidoc
@@ -1,0 +1,41 @@
+= Guidelines
+In order to make `devonfw-docgen` work properly please follow these guidelines:
+
+* Maintain the documentation as collection of http://www.methods.co.nz/asciidoc/[AsciiDoc] pages.
+* If you are using github wikis this is not the default: Always switch `Edit mode` to `AsciiDoc` when creating new wiki pages.
+* For help on the syntax consult the http://asciidoctor.org/docs/asciidoc-writers-guide/[writers guide] and the https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[quick reference].
+* Start every page with the following AsciiDoc header:
++
+[source,asciidoc]
+--------
+:toc: macro
+toc::[]
+:idprefix:
+:idseparator: -
+--------
++
+* In order to make internal links work both in asciidoc pages as well as in generated documentation (PDF, ePub, HTML) you need to stick to this rules:
+** Do not use special characters (dot, ampersand, etc.) in section titles (use plain text e.g. "My Section")
+** If you link to a section, you simply use the section title in lower case with hyphens instead of spaces (e.g. "my-section"). Within the same asciidoc page you use `xref` (e.g. `xref :my-section[link title]`) and between asciidoc pages you use `link` (e.g. `link :«pagename».asciidoc#«section-name»[«link title»]`).
+** In case you want to reference the top-level section of a wiki page you need to use +link+ without a section reference (e.g. `link :«pagename».asciidoc[«link title»]`) and NOT `xref` even if you place the link within the same asciidoc page.
+** From asciidoc pages included in the generated documentation only use `link:` to other asciidoc pages that will also be part of the generated documentation. Otherwise you would produce dead links.
+* For editing larger files and offline work we recommend to clone the asciidoc documentation with git and use an xref:asciidoc-tools[AsciiDoc editor tool].
+* You need to ensure that the files use UTF-8 as encoding.
+* To include images you need to follow this rules:
+** The best choice for high quality rendering is `SVG`. As the wiki does not create mimetypes you have to 
+put the image on the https://github.com/devonfw/devonfw.github.io/[github pages].
+** You have to set the size so it gets properly rendered in the PDF. The width value to make it fit properly on the PDF page is `450`:
++
+[source,asciidoc]
+--------
+.Image Title
+image::http://devonfw.github.io/devon4j/images/«MyImage».«format»["alt-text", width="450", link="http://devonfw.github.io/devon4j/images/«MyImage».«format»"]
+--------
+* For devonfw the asciidoc pages belong to categories that are also reflected by a naming convention:
+** `coding-*` is used for pages about general aspects to development and writing code.
+** `guide-*` is used for pages that act as a guide to a specific topic. It describes what to do and how to do it for that topic from the perspective of a developer.
+** `alternative-*` is used for pages that are not part of the suggested standard but are commonly used or popular alternatives to a proposed standard solution. Such page explains how to use such an alternative solution.
+** `architecture` is reserved for the architecture documentation.
+** `introduction-*` is used for pages that are part of the introduction into the documentation (motivation and general goals).
+** `devonfw-*` is used for pages that are about the devonfw itself and will not be part of the official documentation.
+** `tutorial-*` is used for pages that are part of the tutorials.

--- a/documentation/master.asciidoc
+++ b/documentation/master.asciidoc
@@ -1,0 +1,21 @@
+= devonfw Documentation Generator
+The devonfw community
+${project.version}, ${buildtime}: Subtitle {doctitle}
+:sectnums:
+:toc:
+:toc-title: Table of Contents
+toc::[]
+
+DocGen is a tool that can generate a complete and self-contained documentation as PDF, ePub or HTML from Asciidoc pages.
+
+include::features.asciidoc[leveloffset=1]
+
+include::usage.asciidoc[leveloffset=1]
+
+include::guidelines.asciidoc[leveloffset=1]
+
+include::migration.asciidoc[leveloffset=1]
+
+include::tools.asciidoc[leveloffset=1]
+
+include::credits.asciidoc[leveloffset=1]

--- a/documentation/migration.asciidoc
+++ b/documentation/migration.asciidoc
@@ -1,0 +1,5 @@
+= Migration
+
+If you migrate from `devon-docgen` to `devonfw-docgen` (5.0.0+), you have to choose your target output format to generate via the `artifactId` of the `docgen` parent in your `pom.xml`. So instead of the `artifactId` which was `devon-docgen` you now have to use `devonfw-docgen-pdf` (or `devonfw-docgen-html` in case you generate HTML output).
+
+Also you need to know that the property `docgen.wiki.page` has been renamed to `docgen.asciidoc.page`.

--- a/documentation/tools.asciidoc
+++ b/documentation/tools.asciidoc
@@ -1,0 +1,11 @@
+= Tools
+
+You can clone the documentation from the github repositoriy and edit it with an editor of your choice. For this we recommend one of the following tools:
+
+* http://www.asciidocfx.com/[AsciiDocFx]
+* https://plugins.jetbrains.com/plugin/7391-asciidoc[AsciiDoc for IntelliJ]
+* https://marketplace.visualstudio.com/items?itemName=joaompinto.asciidoctor-vscode[AsciiDoc for VS Code]
+* https://addons.mozilla.org/fr/firefox/addon/asciidoctorjs-live-preview/[Asciidoc for Firefox]
+* https://chrome.google.com/webstore/detail/asciidoctorjs-live-previe/iaalpfgpbocpdfblpnhhgllgbdbchmia[Asciidoc for Chrome]
+* https://atom.io/packages/asciidoc-preview[Asciidoc preview for Atom] and https://atom.io/packages/language-asciidoc[Asciidoc language for Atom]
+* https://github.com/asciidoctor/brackets-asciidoc-preview[Asciidoc for Brackets]

--- a/documentation/usage.asciidoc
+++ b/documentation/usage.asciidoc
@@ -1,0 +1,62 @@
+= Usage
+
+== Setup
+1. Clone your git repository containing the asciidoc documentation to your local machine
+2. Create a pom.xml in the cloned repository (in `devonfw` inside the `documentation` subfolder) with the following content:
++
+```xml
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.devonfw.tools</groupId>
+    <artifactId>devonfw-docgen-«format»</artifactId>
+    <version>5.0.0</version>
+  </parent>
+  <groupId>my.group.id</groupId>
+  <artifactId>my-artifact-id</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>My Cool Wiki</name>
+
+  <properties>
+    <docgen.asciidoc.page>«main-page»</docgen.asciidoc.page>
+  </properties>
+</project>
+```
+For `«format»` please fill in `pdf`, `html`, `epub`, or `all` to decide which format(s) you want to generate.
+For «main-page» fill in the filename of your main AsciiDoc file (without extension) to use as entry point for the generation.
+This file should contain the main title and configuration together with all the `include` directives to the individual AsciiDoc pages to include into your document.
+In case your project is not part of `devonfw` then also override the maven POM config (e.g. `licenses`, `scm`, `url`, `developers`, etc.) to suite to your needs.
+3. Add, commit and push it to github:
++
+[source,cmd]
+--------
+git add pom.xml
+git commit -m "added pom.xml for docgen"
+git push
+--------
+4. Optional custom theme:
+You can develop your own style by using the asciidoctor facilities. Therefore create your own theme in the path `theme/custom-theme.yml` and also push it together with your documentation.
+
+== Generation
+To start the generation manually you need to clone the documentation to generate as described above. Then open a command shell in the cloned project and call:
+[source,cmd]
+--------
+mvn clean package
+--------
+
+Then you will find the result in `target/generated-docs/`.
+
+If you want to deploy your documentation (e.g. to maven central) run:
+[source,cmd]
+--------
+mvn deploy -Pdeploy
+--------
+
+== Configuration
+You can tweak several configuration options. However, the defauls make sense and we recommend "convention-over-configuration".
+In case something does not fit, simply check the `properties` in our https://github.com/devonfw/docgen/blob/master/pom.xml[parent POM].
+For details also read the https://asciidoctor.org/docs/asciidoctor-maven-plugin/#configuration[asciidoctor-maven-plugin documentation].

--- a/html/pom.xml
+++ b/html/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.devonfw.tools</groupId>
+    <artifactId>devonfw-docgen</artifactId>
+    <version>${revision}${changelist}</version>
+  </parent>
+  <artifactId>devonfw-docgen-html</artifactId>
+  <packaging>pom</packaging>
+  <name>${project.artifactId}</name>
+  <description>Generates documentation as HTML from AsciiDoc pages.</description>
+
+  <properties>
+    <docgen.highlighter>highlightjs</docgen.highlighter>
+    <docgen.backend>html5</docgen.backend>
+    <docgen.output.format>html</docgen.output.format>
+  </properties>
+
+</project>

--- a/html/pom.xml
+++ b/html/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.devonfw.tools</groupId>
     <artifactId>devonfw-docgen</artifactId>
-    <version>${revision}${changelist}</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>devonfw-docgen-html</artifactId>
   <packaging>pom</packaging>

--- a/init/pom.xml
+++ b/init/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.devonfw.tools</groupId>
+    <artifactId>devonfw-docgen</artifactId>
+    <version>${revision}${changelist}</version>
+  </parent>
+  <artifactId>devonfw-docgen-init</artifactId>
+  <packaging>pom</packaging>
+  <name>${project.artifactId}</name>
+  <description>Internal module to copy documentation to all modules.</description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <configuration>
+          <resources>
+            <resource>
+              <directory>${basedir}/../</directory>
+              <includes>
+                <include>*.asciidoc</include>
+              </includes>
+            </resource>
+          </resources>
+        </configuration>
+        <executions>
+          <execution>
+            <id>copy-asciidoc-all</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${basedir}/../all/</outputDirectory>
+            </configuration>
+          </execution>
+          <execution>
+            <id>copy-asciidoc-html</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${basedir}/../html/</outputDirectory>
+            </configuration>
+          </execution>
+          <execution>
+            <id>copy-asciidoc-pdf</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${basedir}/../pdf/</outputDirectory>
+            </configuration>
+          </execution>
+          <execution>
+            <id>copy-asciidoc-init</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${basedir}/</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/init/pom.xml
+++ b/init/pom.xml
@@ -24,7 +24,7 @@
             <resource>
               <directory>${basedir}/../</directory>
               <includes>
-                <include>*.asciidoc</include>
+                <include>documentation/**/*</include>
               </includes>
             </resource>
           </resources>

--- a/init/pom.xml
+++ b/init/pom.xml
@@ -6,10 +6,11 @@
   <parent>
     <groupId>com.devonfw.tools</groupId>
     <artifactId>devonfw-docgen</artifactId>
-    <version>${revision}${changelist}</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>devonfw-docgen-init</artifactId>
   <packaging>pom</packaging>
+  <version>dev-SNAPSHOT</version>
   <name>${project.artifactId}</name>
   <description>Internal module to copy documentation to all modules.</description>
 

--- a/pdf/pom.xml
+++ b/pdf/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.devonfw.tools</groupId>
+    <artifactId>devonfw-docgen</artifactId>
+    <version>${revision}${changelist}</version>
+  </parent>
+  <artifactId>devonfw-docgen-pdf</artifactId>
+  <packaging>pom</packaging>
+  <name>${project.artifactId}</name>
+  <description>Generates documentation as PDF from AsciiDoc pages.</description>
+
+  <properties>
+    <!-- <docgen.highlighter>coderay</docgen.highlighter> <docgen.backend>pdf</docgen.backend> 
+      <docgen.output.format>pdf</docgen.output.format> -->
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-doc</id>
+            <goals>
+              <goal>attach-artifact</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <skip>${asciidoctor.skip}</skip>
+              <artifacts>
+                <artifact>
+                  <file>${docgen.generated.docs}/${docgen.wiki.page}.${docgen.output.format}</file>
+                  <type>${docgen.output.format}</type>
+                </artifact>
+              </artifacts>
+              <archive>
+                <addMavenDescriptor>true</addMavenDescriptor>
+              </archive>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/pdf/pom.xml
+++ b/pdf/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.devonfw.tools</groupId>
     <artifactId>devonfw-docgen</artifactId>
-    <version>${revision}${changelist}</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>devonfw-docgen-pdf</artifactId>
   <packaging>pom</packaging>

--- a/pdf/pom.xml
+++ b/pdf/pom.xml
@@ -34,7 +34,7 @@
               <skip>${asciidoctor.skip}</skip>
               <artifacts>
                 <artifact>
-                  <file>${docgen.generated.docs}/${docgen.wiki.page}.${docgen.output.format}</file>
+                  <file>${docgen.generated.docs}/${docgen.asciidoc.page}.${docgen.output.format}</file>
                   <type>${docgen.output.format}</type>
                 </artifact>
               </artifacts>

--- a/pom.xml
+++ b/pom.xml
@@ -16,11 +16,11 @@
 
   <properties>
     <github.repository>devon-docgen</github.repository>
-    <docgen.asciidoc.page>master</docgen.asciidoc.page>
-    <docgen.asciidoc.source>${basedir}/documentation</docgen.asciidoc.source>
-    <docgen.asciidoc.target>${basedir}/target/asciidoc/</docgen.asciidoc.target>
+    <docgen.asciidoc.page>documentation/master</docgen.asciidoc.page>
+    <docgen.asciidoc.source>${basedir}</docgen.asciidoc.source>
+    <docgen.asciidoc.target>${basedir}/target/asciidoc</docgen.asciidoc.target>
     <docgen.asciidoc.extension>asciidoc</docgen.asciidoc.extension>
-    <docgen.generated.docs>${basedir}/target/generated-docs/</docgen.generated.docs>
+    <docgen.generated.docs>${basedir}/target/generated-docs</docgen.generated.docs>
     <docgen.images.dir>images</docgen.images.dir>
     <docgen.highlighter>coderay</docgen.highlighter>
     <docgen.headerFooter>true</docgen.headerFooter>
@@ -336,5 +336,18 @@
         </plugins>
       </build>
     </profile>
+    <!--
+    <profile>
+      <id>documentation-folder</id>
+      <activation>
+        <file>
+          <exists>./documentation</exists>
+        </file>
+      </activation>
+      <properties>
+        <docgen.asciidoc.source>./documentation</docgen.asciidoc.source>
+      </properties>
+    </profile>
+      -->
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,41 +2,51 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.devonfw</groupId>
+    <artifactId>maven-parent</artifactId>
+    <version>2</version>
+  </parent>
   <groupId>com.devonfw.tools</groupId>
-  <artifactId>devon-docgen</artifactId>
-  <version>4.1.0</version>
+  <artifactId>devonfw-docgen</artifactId>
+  <version>${revision}${changelist}</version>
   <packaging>pom</packaging>
   <name>${project.artifactId}</name>
-  <description>Documentation generator that can generate a complete and self-contained documentation as PDF, ePub and HTML from Asciidoc wiki pages.</description>
+  <description>Generates documentation as PDF, ePub or HTML from AsciiDoc wiki pages.</description>
 
   <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <github.project>devonfw/devon-docgen</github.project>
+    <github.repository>devon-docgen</github.repository>
     <docgen.wiki.page>README</docgen.wiki.page>
     <docgen.asciidoc.source>${basedir}</docgen.asciidoc.source>
     <docgen.asciidoc.target>${basedir}/target/asciidoc/</docgen.asciidoc.target>
+    <docgen.asciidoc.extension>asciidoc</docgen.asciidoc.extension>
     <docgen.generated.docs>${basedir}/target/generated-docs/</docgen.generated.docs>
     <docgen.images.dir>images</docgen.images.dir>
+    <docgen.highlighter>coderay</docgen.highlighter>
+    <docgen.headerFooter>true</docgen.headerFooter>
+    <docgen.preserveDirectories>true</docgen.preserveDirectories>
+    <docgen.linkcss>true</docgen.linkcss>
+    <docgen.toc>right</docgen.toc>
+    <docgen.icons>font</docgen.icons>
+    <docgen.idseparator>-</docgen.idseparator>
+    <docgen.highlighter>coderay</docgen.highlighter>
+    <docgen.backend>pdf</docgen.backend>
+    <docgen.output.format>pdf</docgen.output.format>
     <buildtime>${maven.build.timestamp}</buildtime>
     <maven.build.timestamp.format>yyyy-MM-dd_HH.mm.ss</maven.build.timestamp.format>
     <asciidoctor.maven.plugin.version>1.6.0</asciidoctor.maven.plugin.version>
     <asciidoctorj.pdf.version>1.5.0-alpha.18</asciidoctorj.pdf.version>
+    <asciidoctorj.epub.version>1.5.0-alpha.9</asciidoctorj.epub.version>
+    <jruby.version>9.2.8.0</jruby.version>
     <asciidoctor.skip>false</asciidoctor.skip>
-    <!-- You have to define the target format by a console parameter: -Doutput.format=pdf / -Doutput.format=html -->
   </properties>
 
-  <url>https://github.com/${github.project}</url>
-  <issueManagement>
-    <system>GitHub</system>
-    <url>https://github.com/${github.project}/issues</url>
-  </issueManagement>
-
-  <scm>
-    <connection>scm:git:git@github.com:${github.project}.git</connection>
-    <developerConnection>scm:git:git@github.com:${github.project}.git</developerConnection>
-    <url>git@github.com:${github.project}.git</url>
-  </scm>
+  <modules>
+    <module>init</module>
+    <module>pdf</module>
+    <module>html</module>
+    <module>all</module>
+  </modules>
 
   <developers>
     <developer>
@@ -64,48 +74,11 @@
     </contributor>
   </contributors>
 
-  <organization>
-    <name>DevonFw</name>
-    <url>http://devonfw.com/</url>
-  </organization>
-
-  <licenses>
-    <license>
-      <name>Apache Software License, Version 2.0</name>
-      <url>https://github.com/devonfw/devon-docgen/blob/master/LICENSE</url>
-      <distribution>repo</distribution>
-      <comments/>
-    </license>
-  </licenses>
-
   <build>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-site-plugin</artifactId>
-        <version>3.7.1</version>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.8.2</version>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>3.0.0</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.apache.maven.doxia</groupId>
-            <artifactId>doxia-site-renderer</artifactId>
-            <version>1.8.1</version>
-          </dependency>
-        </dependencies>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.8</version>
         <dependencies>
           <dependency>
             <groupId>ant-contrib</groupId>
@@ -136,77 +109,73 @@
             <configuration>
               <skip>${asciidoctor.skip}</skip>
               <target>
-                <taskdef resource="net/sf/antcontrib/antlib.xml"/>
+                <taskdef resource="net/sf/antcontrib/antlib.xml" />
 
                 <for param="asciidoc-file">
                   <path>
                     <fileset dir="${docgen.asciidoc.source}" casesensitive="yes">
-                      <include name="**/*.asciidoc"/>
+                      <exclude name="**/target/**" />
+                      <include name="**/*.${docgen.asciidoc.extension}" />
                     </fileset>
                   </path>
                   <sequential>
 
                     <!-- unset variable to ensure it is properly updated in next property and dirname tasks -->
-                    <var name="path_to_copy_to" unset="true"/>
-                    <var name="file_path" unset="true"/>
+                    <var name="path_to_copy_to" unset="true" />
+                    <var name="file_path" unset="true" />
 
 
-                    <property name="path_to_copy_to" value=""/>
-                    <dirname property="file_path" file="@{asciidoc-file}"/>
+                    <property name="path_to_copy_to" value="" />
+                    <dirname property="file_path" file="@{asciidoc-file}" />
 
                     <!-- Remove the path from the root directory until current sourceDirectory to obtain a relative path -->
-                    <script language="javascript" classpathref="maven.plugin.classpath">
-                      // overwrite existing property.
-                      project.setProperty(
-                      'path_to_copy_to',
-                      project.getProperty('file_path').replace(
-                      project.getProperty('basedir'),
-                      ''
-                      ).replace(/\\/g,
-                      '/').replace('/', ''));
-                    </script>
+                    <script language="beanshell"><![CDATA[
+                      String path = project.getProperty("file_path");
+                      String source = project.getProperty("docgen.asciidoc.source");
+                      path = path.replace(source, "");                      
+                      project.setProperty("path_to_copy_to", path);
+                    ]]></script>
 
                     <!-- unset variable to ensure it is properly updated in next basename task -->
-                    <var name="filename" unset="true"/>
-                    <!--<basename property="filename" file="@{asciidoc-file}" suffix=".asciidoc"/> -->
-                    <basename property="filename" file="@{asciidoc-file}"/>
+                    <var name="filename" unset="true" />
+                    <basename property="filename" file="@{asciidoc-file}" />
                     <copy file="@{asciidoc-file}" todir="${docgen.asciidoc.target}${path_to_copy_to}"
                       encoding="${project.build.sourceEncoding}" outputencoding="${project.reporting.outputEncoding}"
                       verbose="true">
                       <filterchain>
                         <tokenfilter>
-                          <linetokenizer/>
+                          <linetokenizer />
                           <!-- make anchors unique by prefixing with filename -->
-                          <replaceregex pattern="\[\[" replace="[[${filename}_" flags="g"/>
+                          <replaceregex pattern="\[\[" replace="[[${filename}_" flags="g" />
                           <!-- automatically generate anchors for sections -->
                           <replaceregex pattern="^(==+) (.*)"
-                            replace="[[${filename}_\2]]${line.separator}\1 \2" flags="g"/>
+                            replace="[[${filename}_\2]]${line.separator}\1 \2" flags="g" />
 
                           <!-- fix includes to contain asciidoc suffix (what is omitted on github wiki) -->
                           <replaceregex pattern="include\:\:(.*)\[" replace="include::\1.asciidoc["
-                            flags="g"/>
+                            flags="g" />
                           <replaceregex
                             pattern="include\:\:(.*)((\.adoc)|(\.asc)|(\.asciidoc))(\.asciidoc)\["
-                            replace="include::\1\2[" flags="g"/>
+                            replace="include::\1\2[" flags="g" />
 
                           <!-- fix xrefs with default linktext to also include filename prefix -->
                           <replaceregex pattern="xref:([^\[]*)\[\]" replace="xref:${filename}_\1[\1]"
-                            flags="g"/>
+                            flags="g" />
                           <!-- fix xrefs to also include filename prefix -->
-                          <replaceregex pattern="xref:([^\[]*)\[" replace="xref:${filename}_\1[" flags="g"/>
+                          <replaceregex pattern="xref:([^\[]*)\[" replace="xref:${filename}_\1[" flags="g" />
                           <!-- fix links without linktext -->
-                          <replaceregex pattern="link:([^#:]*)\[\]" replace="link:\1[\1]" flags="g"/>
+                          <replaceregex pattern="link:([^#:]*)\[\]" replace="link:\1[\1]" flags="g" />
                           <!-- fix links to contain .asciidoc suffix if omitted (wiki) -->
                           <replaceregex pattern="link:([^#:.\[]*)(#|\[)" replace="xref:\1.asciidoc\2"
-                            flags="g"/>
+                            flags="g" />
                           <!-- fix links to entire asciidoc file (wiki page) by converting into xref inter document ref -->
-                          <replaceregex pattern="link:([^#:]*)\[" replace="xref:\1[" flags="g"/>
-                          <!-- fix links to anchor in other file (wik page) with default linktext by converting into xref
+                          <replaceregex pattern="link:([^#:]*)\[" replace="xref:\1[" flags="g" />
+                          <!-- fix links to anchor in other file (wik page) with default linktext by converting into xref 
                             inter document ref -->
                           <replaceregex pattern="link:([^#:]*)#([^\[]*)\[\]" replace="xref:\1_\2[\1#\2]"
-                            flags="g"/>
+                            flags="g" />
                           <!-- fix links to anchor in other file (wik page) by converting into xref inter document ref -->
-                          <replaceregex pattern="link:([^#:]*)#([^\[]*)\[" replace="xref:\1_\2[" flags="g"/>
+                          <replaceregex pattern="link:([^#:]*)#([^\[]*)\[" replace="xref:\1_\2[" flags="g" />
                           <scriptfilter language="beanshell" byline="true" setbeans="true"><![CDATA[
                             String text = self.getToken();
                             if (text.startsWith("[[")) {
@@ -217,16 +186,16 @@
                               }
                             }
                           ]]></scriptfilter>
-                          <!-- insert top-level anchor for file so links to this enire file work after being resolved as
+                          <!-- insert top-level anchor for file so links to this enire file work after being resolved as 
                             xref -->
                           <replaceregex pattern="^(=) " replace="[[${filename}]]${line.separator}\1 "
-                            flags="g"/>
+                            flags="g" />
                           <!-- resolve maven variables -->
                           <replaceregex pattern="\$\{project\.version\}" replace="${project.version}"
-                            flags="g"/>
+                            flags="g" />
                           <replaceregex pattern="\$\{project\.artifactId\}" replace="${project.artifactId}"
-                            flags="g"/>
-                          <replaceregex pattern="\$\{buildtime\}" replace="${buildtime}" flags="g"/>
+                            flags="g" />
+                          <replaceregex pattern="\$\{buildtime\}" replace="${buildtime}" flags="g" />
                         </tokenfilter>
                       </filterchain>
                     </copy>
@@ -237,11 +206,12 @@
                 <copy todir="${docgen.asciidoc.target}" encoding="${project.build.sourceEncoding}">
                   <path>
                     <fileset dir="${docgen.asciidoc.source}">
-                      <exclude name="**/*.asciidoc"/>
-                      <exclude name="**/target/**"/>
-                      <exclude name="**/${docgen.images.dir}/**/*"/>
+                      <exclude name="**/*.${docgen.asciidoc.extension}" />
+                      <exclude name="**/target/**" />
+                      <exclude name="**/pom.xml" />
+                      <exclude name="**/${docgen.images.dir}/**/*" />
                       <!-- exclude local m2 repository in Jenkins builds -->
-                      <exclude name="**/.repository/**"/>
+                      <exclude name="**/.repository/**" />
                     </fileset>
                   </path>
                 </copy>
@@ -253,7 +223,7 @@
                     <for param="imagesdir">
                       <path>
                         <dirset dir="${docgen.asciidoc.source}" casesensitive="yes">
-                          <include name="**/@{receiveddir}/**"/>
+                          <include name="**/@{receiveddir}/**" />
                         </dirset>
                       </path>
                       <sequential>
@@ -261,7 +231,7 @@
                         <copy todir="${docgen.asciidoc.target}/@{receiveddir}">
                           <path>
                             <fileset dir="@{imagesdir}">
-                              <include name="**/*"/>
+                              <include name="**/*" />
                             </fileset>
                           </path>
                         </copy>
@@ -291,146 +261,62 @@
           <dependency>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj-epub3</artifactId>
-            <version>1.5.0-alpha.9</version>
+            <version>${asciidoctorj.epub.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.jruby</groupId>
+            <artifactId>jruby-complete</artifactId>
+            <version>${jruby.version}</version>
           </dependency>
         </dependencies>
         <configuration>
+          <skip>${asciidoctor.skip}</skip>
           <sourceDirectory>${docgen.asciidoc.target}</sourceDirectory>
+          <sourceDocumentName>${docgen.wiki.page}.${docgen.asciidoc.extension}</sourceDocumentName>
           <imagesDir>${docgen.generated.docs}</imagesDir>
-          <headerFooter>true</headerFooter>
+          <backend>${docgen.backend}</backend>
+          <sourceHighlighter>${docgen.highlighter}</sourceHighlighter>
+          <headerFooter>${docgen.headerFooter}</headerFooter>
+          <preserveDirectories>${docgen.preserveDirectories}</preserveDirectories>
           <attributes>
-            <allow-uri-read/>
+            <allow-uri-read />
+            <icons>${docgen.icons}</icons>
+            <pagenums />
+            <experimental />
+            <toc>${docgen.toc}</toc>
+            <baseDir>./</baseDir>
+            <linkcss>${docgen.linkcss}</linkcss>
+            <idprefix />
+            <idseparator>${docgen.idseparator}</idseparator>
           </attributes>
         </configuration>
+        <executions>
+          <execution>
+            <id>generate-doc</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>process-asciidoc</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
+    <!-- should actually be moved to maven-parent -->
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>3.0.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
   <profiles>
     <profile>
-      <id>generate-pdf</id>
-      <activation>
-        <property>
-          <name>output.format</name>
-          <value>pdf</value>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>build-helper-maven-plugin</artifactId>
-            <version>3.0.0</version>
-            <executions>
-              <execution>
-                <id>attach-pdf</id>
-                <goals>
-                  <goal>attach-artifact</goal>
-                </goals>
-                <phase>package</phase>
-                <configuration>
-                  <skip>${asciidoctor.skip}</skip>
-                  <artifacts>
-                    <artifact>
-                      <file>${docgen.generated.docs}/${docgen.wiki.page}.pdf</file>
-                      <type>pdf</type>
-                    </artifact>
-                  </artifacts>
-                  <archive>
-                    <addMavenDescriptor>true</addMavenDescriptor>
-                  </archive>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
-      <id>oss</id>
-      <build>
-        <plugins>
-          <!-- Sign artifacts with PGP -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
-            <configuration>
-              <keyname>${gpg.keyname}</keyname>
-            </configuration>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-      <distributionManagement>
-        <snapshotRepository>
-          <id>ossrh</id>
-          <url>https://oss.sonatype.org/content/repositories/releases</url>
-        </snapshotRepository>
-        <repository>
-          <id>ossrh</id>
-          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-      </distributionManagement>
-    </profile>
-    <profile>
-      <id>default-style</id>
-      <activation>
-        <property>
-          <name>output.format</name>
-          <value>pdf</value>
-        </property>
-        <file>
-          <missing>./theme/custom-theme.yml</missing>
-        </file>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.asciidoctor</groupId>
-            <artifactId>asciidoctor-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>generate-pdf-doc</id>
-                <phase>compile</phase>
-                <goals>
-                  <goal>process-asciidoc</goal>
-                </goals>
-                <configuration>
-                  <skip>${asciidoctor.skip}</skip>
-                  <sourceDocumentName>${docgen.wiki.page}.asciidoc</sourceDocumentName>
-                  <backend>pdf</backend>
-                  <sourceHighlighter>coderay</sourceHighlighter>
-                  <attributes>
-                    <icons>font</icons>
-                    <pagenums/>
-                    <toc/>
-                    <idprefix/>
-                    <idseparator>-</idseparator>
-                  </attributes>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>custom-style</id>
       <activation>
-        <property>
-          <name>output.format</name>
-          <value>pdf</value>
-        </property>
         <file>
           <exists>./theme/custom-theme.yml</exists>
         </file>
@@ -440,76 +326,12 @@
           <plugin>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctor-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>generate-pdf-doc</id>
-                <phase>compile</phase>
-                <goals>
-                  <goal>process-asciidoc</goal>
-                </goals>
-                <configuration>
-                  <skip>${asciidoctor.skip}</skip>
-                  <sourceDocumentName>${docgen.wiki.page}.asciidoc</sourceDocumentName>
-                  <backend>pdf</backend>
-                  <sourceHighlighter>coderay</sourceHighlighter>
-                  <attributes>
-                    <pdf-stylesdir>${basedir}/theme</pdf-stylesdir>
-                    <pdf-style>custom</pdf-style>
-                    <icons>font</icons>
-                    <pagenums/>
-                    <toc/>
-                    <idprefix/>
-                    <idseparator>-</idseparator>
-                  </attributes>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>generate-html-docs</id>
-      <activation>
-        <property>
-          <name>output.format</name>
-          <value>html</value>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.asciidoctor</groupId>
-            <artifactId>asciidoctor-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>generate-html-doc</id>
-                <phase>compile</phase>
-                <goals>
-                  <goal>process-asciidoc</goal>
-                </goals>
-                <configuration>
-                  <skip>${asciidoctor.skip}</skip>
-                  <preserveDirectories>true</preserveDirectories>
-                  <imagesDir>${docgen.generated.docs}</imagesDir>
-                  <sourceDirectory>${docgen.asciidoc.target}</sourceDirectory>
-                  <outputDirectory>${docgen.generated.docs}</outputDirectory>
-                  <backend>html5</backend>
-                  <sourceHighlighter>highlightjs</sourceHighlighter>
-                  <eruby>erb</eruby>
-                  <attributes>
-                    <icons>font</icons>
-                    <experimental/>
-                    <toc>right</toc>
-                    <pagenums/>
-                    <idprefix/>
-                    <idseparator>-</idseparator>
-                    <baseDir>./</baseDir>
-                    <linkcss>true</linkcss>
-                  </attributes>
-                </configuration>
-              </execution>
-            </executions>
+            <configuration>
+              <attributes>
+                <pdf-stylesdir>${basedir}/theme</pdf-stylesdir>
+                <pdf-style>custom</pdf-style>
+              </attributes>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
 
   <properties>
     <github.repository>devon-docgen</github.repository>
-    <docgen.wiki.page>README</docgen.wiki.page>
-    <docgen.asciidoc.source>${basedir}</docgen.asciidoc.source>
+    <docgen.asciidoc.page>master</docgen.asciidoc.page>
+    <docgen.asciidoc.source>${basedir}/documentation</docgen.asciidoc.source>
     <docgen.asciidoc.target>${basedir}/target/asciidoc/</docgen.asciidoc.target>
     <docgen.asciidoc.extension>asciidoc</docgen.asciidoc.extension>
     <docgen.generated.docs>${basedir}/target/generated-docs/</docgen.generated.docs>
@@ -272,7 +272,7 @@
         <configuration>
           <skip>${asciidoctor.skip}</skip>
           <sourceDirectory>${docgen.asciidoc.target}</sourceDirectory>
-          <sourceDocumentName>${docgen.wiki.page}.${docgen.asciidoc.extension}</sourceDocumentName>
+          <sourceDocumentName>${docgen.asciidoc.page}.${docgen.asciidoc.extension}</sourceDocumentName>
           <imagesDir>${docgen.generated.docs}</imagesDir>
           <backend>${docgen.backend}</backend>
           <sourceHighlighter>${docgen.highlighter}</sourceHighlighter>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <docgen.asciidoc.target>${basedir}/target/asciidoc</docgen.asciidoc.target>
     <docgen.asciidoc.extension>asciidoc</docgen.asciidoc.extension>
     <docgen.generated.docs>${basedir}/target/generated-docs</docgen.generated.docs>
+    <docgen.docsource>${docgen.asciidoc.page}.${docgen.asciidoc.extension}</docgen.docsource>
     <docgen.images.dir>images</docgen.images.dir>
     <docgen.highlighter>coderay</docgen.highlighter>
     <docgen.headerFooter>true</docgen.headerFooter>
@@ -37,7 +38,7 @@
     <asciidoctor.maven.plugin.version>1.6.0</asciidoctor.maven.plugin.version>
     <asciidoctorj.pdf.version>1.5.0-alpha.18</asciidoctorj.pdf.version>
     <asciidoctorj.epub.version>1.5.0-alpha.9</asciidoctorj.epub.version>
-    <jruby.version>9.2.8.0</jruby.version>
+    <jruby.version>9.2.6.0</jruby.version>
     <asciidoctor.skip>false</asciidoctor.skip>
   </properties>
 
@@ -130,16 +131,16 @@
 
                     <!-- Remove the path from the root directory until current sourceDirectory to obtain a relative path -->
                     <script language="beanshell"><![CDATA[
-                      String path = project.getProperty("file_path");
-                      String source = project.getProperty("docgen.asciidoc.source");
-                      path = path.replace(source, "");                      
+                      String path = project.getProperty("file_path").replace("\\", "/");
+                      String source = project.getProperty("docgen.asciidoc.source").replace("\\", "/");
+                      path = path.replace(source, "");
                       project.setProperty("path_to_copy_to", path);
                     ]]></script>
 
                     <!-- unset variable to ensure it is properly updated in next basename task -->
                     <var name="filename" unset="true" />
                     <basename property="filename" file="@{asciidoc-file}" />
-                    <copy file="@{asciidoc-file}" todir="${docgen.asciidoc.target}${path_to_copy_to}"
+                    <copy file="@{asciidoc-file}" todir="${docgen.asciidoc.target}/${path_to_copy_to}"
                       encoding="${project.build.sourceEncoding}" outputencoding="${project.reporting.outputEncoding}"
                       verbose="true">
                       <filterchain>
@@ -272,12 +273,14 @@
         <configuration>
           <skip>${asciidoctor.skip}</skip>
           <sourceDirectory>${docgen.asciidoc.target}</sourceDirectory>
-          <sourceDocumentName>${docgen.asciidoc.page}.${docgen.asciidoc.extension}</sourceDocumentName>
+          <sourceDocumentName>${docgen.docsource}</sourceDocumentName>
           <imagesDir>${docgen.generated.docs}</imagesDir>
           <backend>${docgen.backend}</backend>
+          <outputDirectory>${docgen.generated.docs}</outputDirectory>
           <sourceHighlighter>${docgen.highlighter}</sourceHighlighter>
           <headerFooter>${docgen.headerFooter}</headerFooter>
           <preserveDirectories>${docgen.preserveDirectories}</preserveDirectories>
+          <eruby>erb</eruby>
           <attributes>
             <allow-uri-read />
             <icons>${docgen.icons}</icons>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>com.devonfw.tools</groupId>
   <artifactId>devonfw-docgen</artifactId>
-  <version>${revision}${changelist}</version>
+  <version>5.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>${project.artifactId}</name>
   <description>Generates documentation as PDF, ePub or HTML from AsciiDoc wiki pages.</description>


### PR DESCRIPTION
* #12: avoid JavaScript as Nashorn will be removed from future JDKs
* #13: use new `maven-parent` POM
* #14: increase UX
* changed artifactId from `devon-docgen` to `devonfw-docgen` to follow our standards.
* introcuded ci-friendly-maven

Please note that the `init` module is just a workaround to avoid redundancies.
Should we change the version of `init` to something like `dev-SNAPSHOT` to avoid staging it to maven central? I think this is a good idea - WDYT?