### PR TITLE
Fix Includes to add .asciidoc when not these file types cfg,xml,json,…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
                             replace="[[${filename}_\2]]${line.separator}\1 \2" flags="g" />
 
                           <!-- fix includes to contain asciidoc suffix (what is omitted on github wiki) -->
-                          <replaceregex pattern="include\:\:(?!.*\.)(.*)\[" replace="include::\1.asciidoc["
+                          <replaceregex pattern="include\:\:(.*/)?(?!.*\.)(.*)\[" replace="include::\1.asciidoc["
                             flags="g" />
                            <replaceregex pattern="include\:\:(.*)\/(?!.*\.)(.*)\[" replace="include::\1/\2.asciidoc["
                             flags="g" />

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
                             replace="[[${filename}_\2]]${line.separator}\1 \2" flags="g" />
 
                           <!-- fix includes to contain asciidoc suffix (what is omitted on github wiki) -->
-                          <replaceregex pattern="include\:\:(.*)\[" replace="include::\1.asciidoc["
+                          <replaceregex pattern="include\:\:(.*?)\.(?!cfg|xml|sql|properties|csv|json)\[\]" replace="include::\1.asciidoc["
                             flags="g" />
                           <replaceregex
                             pattern="include\:\:(.*)((\.adoc)|(\.asc)|(\.asciidoc))(\.asciidoc)\["

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
                             replace="[[${filename}_\2]]${line.separator}\1 \2" flags="g" />
 
                           <!-- fix includes to contain asciidoc suffix (what is omitted on github wiki) -->
-                          <replaceregex pattern="include\:\:(.*/)?(?!.*\.)(.*)\[" replace="include::\1.asciidoc["
+                          <replaceregex pattern="include\:\:(.*/)?(?!.*\.)(.*)\[" replace="include::\1\2\3.asciidoc["
                             flags="g" />
                            <replaceregex pattern="include\:\:(.*)\/(?!.*\.)(.*)\[" replace="include::\1/\2.asciidoc["
                             flags="g" />

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,9 @@
                             replace="[[${filename}_\2]]${line.separator}\1 \2" flags="g" />
 
                           <!-- fix includes to contain asciidoc suffix (what is omitted on github wiki) -->
-                          <replaceregex pattern="include\:\:(.*?)\.(?!cfg|xml|sql|properties|csv|json)\[\]" replace="include::\1.asciidoc["
+                          <replaceregex pattern="include\:\:(?!.*\.)(.*)\[" replace="include::\1.asciidoc["
+                            flags="g" />
+                           <replaceregex pattern="include\:\:(.*)\/(?!.*\.)(.*)\[" replace="include::\1/\2.asciidoc["
                             flags="g" />
                           <replaceregex
                             pattern="include\:\:(.*)((\.adoc)|(\.asc)|(\.asciidoc))(\.asciidoc)\["


### PR DESCRIPTION
Currently regex adds .asciidoc extension - Now excluded certain file types from it such as cfg,xml,csv,sql,json,properties file extensions.