### PR TITLE
Fixed broken links for the same folder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
 
                       String filename = project.getProperty("filename");
                       String normalizedPrefix = (path + "/" + filename).replace("/", "_");
-					  if( normalizedPrefix.startsWith("_")) normalizedPrefix=normalizedPrefix.substring(1);
+                      if( normalizedPrefix.startsWith("_")) normalizedPrefix=normalizedPrefix.substring(1);
                       project.setProperty("norm_prefix", normalizedPrefix);
                     ]]></script>
 


### PR DESCRIPTION
This PR will fix the issue that after the [PR:allow asciidoc files to resist in subfolders ](https://github.com/devonfw/docgen/pull/31) some links between files in the same folder were broken.